### PR TITLE
fix missing image

### DIFF
--- a/easy_thumbnails_rest/serializers.py
+++ b/easy_thumbnails_rest/serializers.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.db.models import ImageField
+from django.db.models.fields.files import ImageFieldFile
 from rest_framework.serializers import ImageField as ApiImageField, ListField, JSONField
 from easy_thumbnails.files import ThumbnailerImageFieldFile, get_thumbnailer
 
@@ -11,7 +12,7 @@ def get_url(request, instance, alias=None):
     if alias is not None:
         if isinstance(instance, ThumbnailerImageFieldFile):
             return request.build_absolute_uri(instance[alias].url)
-        elif isinstance(instance, ImageField):
+        elif isinstance(instance, ImageField) or isinstance(instance, ImageFieldFile):
             return request.build_absolute_uri(get_thumbnailer(instance)[alias].url)
     elif alias is None:
         return request.build_absolute_uri(instance.url)


### PR DESCRIPTION
Hi and thansk for sharing,
i'm pretty noob with django
But i'm finding a issue using the serializes.
ENV:
django 3.1
djangorestframework==3.12.2
easy-thumbnails==2.7.1
easy-thumbnails-rest==1.1

THUMBNAIL_ALIASES: rigth configured i'm using the same alias in template ant it is working

my models 
```python
class JewelImage(models.Model):
    class Meta:
        ordering = ['order']
        verbose_name = ('Immagine del gioiello')
        verbose_name_plural = ('Immagini del gioiello')

    order = models.PositiveIntegerField(default=0, blank=False, null=False)
    image = models.ImageField(upload_to="jewel-image/%Y/", verbose_name = "Jewel Image", blank=True, null=True, default=0)
    GioielloClass = models.ForeignKey(Jewel, related_name='gallery', on_delete=models.CASCADE)

    def title(self):
        return self.GioielloClass

    def __str__(self):
        return u'%s' % self.image

```

serializers
```python
class JewelImageSerializer(serializers.ModelSerializer):
    image = MyThumbnailerSerializer(alias='avatar')

    class Meta:
        model = JewelImage
        fields = "__all__"
```

My result
```json
[
    {
        "id": 2,
        "image": null,
        "order": 0,
        "GioielloClass": 1
    },
    {
        "id": 1,
        "image": null,
        "order": 1,
        "GioielloClass": 1
    },
    {
        "id": 3,
        "image": null,
        "order": 2,
        "GioielloClass": 1
    }
]
```

digging in the code i found it is skipping
```python
        elif isinstance(instance, ImageField):
            return request.build_absolute_uri(get_thumbnailer(instance)[alias].url)
```
Because django class is <class 'django.db.models.fields.files.ImageFieldFile'>
Added it with or
I'm wrong in samethics in the model definitons, that is causing this issue ?